### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/autogen_compat/__init__.py
+++ b/autogen_compat/__init__.py
@@ -1,6 +1,6 @@
 """
 Compatibility layer for autogen imports.
-This module redirects imports from 'autogen' to 'pyautogen'.
+This module redirects imports from 'autogen' to 'ag2'.
 """
 
 import sys
@@ -9,21 +9,21 @@ import warnings
 
 # Show a warning about the compatibility layer
 warnings.warn(
-    "Using autogen_compat layer: 'autogen' package is not available, redirecting to 'pyautogen'",
+    "Using autogen_compat layer: 'autogen' package is not available, redirecting to 'ag2'",
     ImportWarning
 )
 
-# Try to import pyautogen
+# Try to import ag2
 try:
-    import pyautogen
+    import ag2
 except ImportError:
     raise ImportError(
-        "Neither 'autogen' nor 'pyautogen' package is installed. "
-        "Please install pyautogen with: pip install pyautogen>=0.2.0"
+        "Neither 'autogen' nor 'ag2' package is installed. "
+        "Please install ag2 with: pip install ag2>=0.2.0"
     )
 
 # Add the module to sys.modules
-sys.modules['autogen'] = pyautogen
+sys.modules['autogen'] = ag2
 
 # Also make submodules available
 for submodule_name in [
@@ -32,8 +32,8 @@ for submodule_name in [
     'function_utils', 'graph_utils', 'retrieve_utils', 'runtime_logging', 'types'
 ]:
     try:
-        submodule = importlib.import_module(f'pyautogen.{submodule_name}')
+        submodule = importlib.import_module(f'ag2.{submodule_name}')
         sys.modules[f'autogen.{submodule_name}'] = submodule
     except ImportError:
-        # If the submodule doesn't exist in pyautogen, just skip it
+        # If the submodule doesn't exist in ag2, just skip it
         pass

--- a/fix_autogen_dependency.sh
+++ b/fix_autogen_dependency.sh
@@ -58,7 +58,7 @@ mkdir -p autogen_compat
 cat > autogen_compat/__init__.py << 'EOL'
 """
 Compatibility layer for autogen imports.
-This module redirects imports from 'autogen' to 'pyautogen'.
+This module redirects imports from 'autogen' to 'ag2'.
 """
 
 import sys
@@ -67,21 +67,21 @@ import warnings
 
 # Show a warning about the compatibility layer
 warnings.warn(
-    "Using autogen_compat layer: 'autogen' package is not available, redirecting to 'pyautogen'",
+    "Using autogen_compat layer: 'autogen' package is not available, redirecting to 'ag2'",
     ImportWarning
 )
 
-# Try to import pyautogen
+# Try to import ag2
 try:
-    import pyautogen
+    import ag2
 except ImportError:
     raise ImportError(
-        "Neither 'autogen' nor 'pyautogen' package is installed. "
-        "Please install pyautogen with: pip install pyautogen>=0.2.0"
+        "Neither 'autogen' nor 'ag2' package is installed. "
+        "Please install ag2 with: pip install ag2>=0.2.0"
     )
 
 # Add the module to sys.modules
-sys.modules['autogen'] = pyautogen
+sys.modules['autogen'] = ag2
 
 # Also make submodules available
 for submodule_name in [
@@ -90,10 +90,10 @@ for submodule_name in [
     'function_utils', 'graph_utils', 'retrieve_utils', 'runtime_logging', 'types'
 ]:
     try:
-        submodule = importlib.import_module(f'pyautogen.{submodule_name}')
+        submodule = importlib.import_module(f'ag2.{submodule_name}')
         sys.modules[f'autogen.{submodule_name}'] = submodule
     except ImportError:
-        # If the submodule doesn't exist in pyautogen, just skip it
+        # If the submodule doesn't exist in ag2, just skip it
         pass
 EOL
 
@@ -129,4 +129,4 @@ fi
 print_header "Fix Complete"
 print_info "To run your application with the compatibility layer, use:"
 echo -e "${YELLOW}./use_autogen_compat.sh streamlit run main.py${NC}"
-print_info "This will ensure that 'import autogen' statements are redirected to 'pyautogen'"
+print_info "This will ensure that 'import autogen' statements are redirected to 'ag2'"


### PR DESCRIPTION
**Subject: Migrate from pyautogen to ag2 Library**

This pull request updates the codebase to use the `ag2` library, replacing instances of `pyautogen`.

`pyautogen` is now considered outdated, and `ag2` is the recommended library for continued development. There are no syntax differences between `pyautogen` and `ag2`; this change primarily involves renaming the library imports and usage.

This migration ensures compatibility with the latest standards and benefits from ongoing improvements in the `ag2` ecosystem.

Please review and merge at your earliest convenience.
